### PR TITLE
Set cwd to module folder

### DIFF
--- a/bundler/browserify.js
+++ b/bundler/browserify.js
@@ -1,4 +1,5 @@
 var gatherOutputs = require('./gather-outputs');
+var path = require('path');
 
 //
 // Run browserify
@@ -50,7 +51,7 @@ module.exports = function (env, options, cb) {
     }
 
     env.log.info('browserify: running browserify with options: `' + JSON.stringify(argv) + '`...');
-    var bfy = env.spawn('browserify', argv);
+    var bfy = env.spawn('browserify', argv, { cwd: 'node_modules/' + module });
 
     gatherOutputs('browserify', bfy, function (err, data) {
       if (err) {


### PR DESCRIPTION
The `browserify-versionify` transform assumes the cwd will be the
module’s folder. It uses `find-root` to traverse upwards and find a
package.json.

Right now the cwd is set to “/tmp/webtorrent115012-16911-2wbt66” when
browserifying. This PR changes it to
“/tmp/webtorrent115012-16911-2wbt66/node_modules/webtorrent”, for
example.

This fixes #92.